### PR TITLE
Destroying an option destroys all its votes

### DIFF
--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,6 +1,6 @@
 class Option < ApplicationRecord
   belongs_to :choice_point
-  has_many :votes
+  has_many :votes, dependent: :destroy
   has_many :users, through: :votes
   validates :description, presence: true
 


### PR DESCRIPTION
This allows seeding to work properly again (it was broken for a while).