### PR TITLE
Added message for when an option has no votes

### DIFF
--- a/app/assets/stylesheets/choicepoint/show.scss
+++ b/app/assets/stylesheets/choicepoint/show.scss
@@ -102,12 +102,18 @@
     border-radius: 0 48px 48px 0;
     padding-left: 0;
   }
-  .show-options-row-score {
+  .show-options-row-score-bar {
     background-color: $pastel-blue;
     box-shadow: 4px 4px 0px $choice-point-yellow;
     height: 50%;
     margin: 0 16px;
     padding: 0;
+  }
+  .show-options-row-score {
+    font-size: $paragraph-size;
+    color: $black;
+    text-transform: uppercase;
+    font-weight: 700;
   }
 }
 

--- a/app/views/choice_points/_voting_area_content.html.erb
+++ b/app/views/choice_points/_voting_area_content.html.erb
@@ -9,8 +9,10 @@
   <p><a class="btn btn-ghost show-options-row-pros-and-cons" href="#">Pros</a></p>
   <p><a class="btn btn-ghost show-options-row-pros-and-cons" href="#">Cons</a></p>
   <!-- spacer div for the grid --> <div></div>
-  <% width = option.score.zero? ? 0 : option.score / highest_score %>
+  <% width = option.score.zero? ? nil : option.score / highest_score %>
   <!-- Not accessible! Should be fixed -->
-  <div class="show-options-row show-options-row-score"
-     style="width: calc(<%= width * 100 %>% - <%= 24 * width %>px);"></div>
+  <p class="show-options-row show-options-row-score <%= "show-options-row-score-bar" if width %>"
+     style=<%= width ? "width: calc(#{width * 100}% - #{24 * width}px);" : "" %>>
+    <%= "No votes yet" if width.nil? %>
+  </p>
 <% end %>


### PR DESCRIPTION
Now when an option on the show page has no votes, there is a message saying "no votes yet", rather than empty space. Any suggestions for a less wordy way of doing this would be appreciated! (Obviously if we decide to add the numbers back in, this could be replaced by "0" or "0%".)

![image](https://user-images.githubusercontent.com/80717525/173044794-431e71f1-8ba1-4141-80d5-3bca8cc04797.png)
