### PR TITLE
More improvements for past choice points

### DIFF
--- a/app/models/choice_point.rb
+++ b/app/models/choice_point.rb
@@ -25,6 +25,13 @@ class ChoicePoint < ApplicationRecord
     end
   end
 
+  def total_votes
+    # Gets the total number of votes for a choice point
+    options.reduce(0) do |tally, option|
+      tally + option.votes.count
+    end
+  end
+
   def highest_score
     # Returns the actual score of the leading option.
     leader&.score

--- a/app/models/choice_point.rb
+++ b/app/models/choice_point.rb
@@ -14,7 +14,10 @@ class ChoicePoint < ApplicationRecord
     }
 
   def vote_from?(user)
-    # Not very efficient: Could be improved via techniques from Advanced DB lecture?
+    # Returns true if user has voted on the choice point, false otherwise.
+
+    # NOTE: Not very efficient: Could be improved via techniques from Advanced
+    # DB lecture?
     options.any? do |option|
       option.votes.any? do |vote|
         vote.user == user
@@ -23,16 +26,21 @@ class ChoicePoint < ApplicationRecord
   end
 
   def highest_score
+    # Returns the actual score of the leading option.
     leader&.score
   end
 
   def leader
+    # Searches through a choice point's options, returns the one with the
+    # highest score.
     options.reduce do |best, current|
       current.score > best.score ? current : best
     end
   end
 
   def expired
+    # Returns true if the choice point has expired, false otherwise.
+    # TODO: Should have named this method with a question mark at the end...
     deadline < Date.today
   end
 end

--- a/app/views/choice_points/_results.html.erb
+++ b/app/views/choice_points/_results.html.erb
@@ -4,7 +4,7 @@
       highest_score: highest_score,
       expired: expired do |option| %>
         <% selected = option.votes.any? { |vote| vote.user == current_user } %>
-        <p class="show-options-check-mark show-options-radio-button-space <%= "selected-area" if selected %> <%= "winning-area" if expired && choice_point.leader == option %>"><%= "✓" if selected %></p>
-        <p class="show-options-row show-options-row-description <%= "selected-area" if selected %> <%= "winning-area" if expired && choice_point.leader == option %>"><%= option.description %></p>
+        <p class="show-options-check-mark show-options-radio-button-space <%= "selected-area" if selected && !expired %> <%= "winning-area" if expired && choice_point.leader == option %>"><%= "✓" if selected %></p>
+        <p class="show-options-row show-options-row-description <%= "selected-area" if selected && !expired%> <%= "winning-area" if expired && choice_point.leader == option %>"><%= option.description %></p>
   <% end %>
 </div>

--- a/app/views/choice_points/_results.html.erb
+++ b/app/views/choice_points/_results.html.erb
@@ -4,7 +4,25 @@
       highest_score: highest_score,
       expired: expired do |option| %>
         <% selected = option.votes.any? { |vote| vote.user == current_user } %>
-        <p class="show-options-check-mark show-options-radio-button-space <%= "selected-area" if selected && !expired %> <%= "winning-area" if expired && choice_point.leader == option %>"><%= "✓" if selected %></p>
-        <p class="show-options-row show-options-row-description <%= "selected-area" if selected && !expired%> <%= "winning-area" if expired && choice_point.leader == option %>"><%= option.description %></p>
+        <p class="show-options-check-mark
+                  show-options-radio-button-space
+                  <% if expired %>
+                    <%= "winning-area" if choice_point.leader == option %>
+                  <% elsif selected %>
+                    <%= "selected-area" %>
+                  <% end %>">
+          <%== "<i class='far fa-check-circle selected-icon'></i>" if selected %>
+          <%== "&nbsp;" if expired && choice_point.leader == option && selected %>
+          <%== "<i class='fas fa-award'></i>" if expired && choice_point.leader == option %>
+        </p>
+        <p class="show-options-row
+                  show-options-row-description
+                  <% if expired %> <%# not DRY %>
+                    <%= "winning-area" if choice_point.leader == option %>
+                  <% elsif selected %>
+                    <%= "selected-area" %>
+                  <% end %>">
+          <%= option.description %>
+        </p>
   <% end %>
 </div>

--- a/app/views/choice_points/_voting_area_content.html.erb
+++ b/app/views/choice_points/_voting_area_content.html.erb
@@ -1,7 +1,7 @@
 <!-- spacer div for the grid --> <div></div>
 <p class="show-options-header-row show-options-row-description">
   <% if expired %>
-    Voting done
+    Ended <%= pluralize((Date.today - choice_point.deadline).to_i, "day") %> ago
   <% else %>
     <%= pluralize((choice_point.deadline - Date.today + 1).to_i, "day") %> left
   <% end %>
@@ -9,7 +9,10 @@
 <!-- spacer div for the grid --> <div></div>
 <!-- spacer div for the grid --> <div></div>
 <!-- spacer div for the grid --> <div></div>
-<p class="show-options-header-row">score</p>
+<p class="show-options-header-row">
+  score
+  (<%= pluralize((choice_point.total_votes), "vote") %>)
+</p>
 <% options = choice_point.options.order(expired ? 'score DESC' : :id) %>
 <% options.each do |option| %>
   <%= yield(option) %>

--- a/app/views/options/_form_option.html.erb
+++ b/app/views/options/_form_option.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for([ choice_point, option ], html: {data:{options_target:"form"}}, remote: true) do |f| %>
+<%= simple_form_for([ choice_point, option ], html: {data:{options_target:"form"}}, remote: true, authenticity_token: true) do |f| %>
   <div class="option-description-container">
     <%= f.input :description, placeholder: 'Option', label: false, :class => "form-field", required: true %>
     <%= f.input :pros, placeholder: 'What you like about it', label:false, :class => "form-field", required: true, as: :text %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,6 +56,7 @@ end
 def create_additional_users
   NUMBER_OF_ADDITIONAL_USERS.times do
     user = Faker::Internet.user
+    # Could be refactored
     User.create!(
       email: user[:email],
       password: '123456',

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,7 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 USERNAMES = ['rmgodfrey', 'aackle00', 'GeoniX404', 'chriswall24']
+NUMBER_OF_ADDITIONAL_USERS = 50
 # Turn this hash into an array to get a random sample
 CHOICE_POINTS = {
   "What should I wear to my job interview?" => ["Button-up shirt", "Suit", "T-shirt"],
@@ -21,6 +22,7 @@ NUMBER_OF_CHOICE_POINTS = 3
 HIGHEST_SCORE = 100
 # Odds that a user votes for a particular choice point.
 VOTE_PROBABILITY = 2.0 / 3.0
+REPUTATION_RANGE = 5..40
 
 def create_users
   USERNAMES.each do |username|
@@ -30,11 +32,12 @@ def create_users
       email: email,
       password: password,
       name: username,
-      reputation: rand(5..40)
+      reputation: rand(REPUTATION_RANGE)
     )
     puts "Created user #{username}\n\tEmail: #{email}\n\tPassword: '#{password}'"
     create_choice_points(user)
   end
+  create_additional_users
 end
 
 def make_users_vote
@@ -46,6 +49,20 @@ def make_users_vote
       vote = Vote.create!(option: option, user: user)
       option.increase_score(vote)
     end
+    puts "#{user.name} has voted"
+  end
+end
+
+def create_additional_users
+  NUMBER_OF_ADDITIONAL_USERS.times do
+    user = Faker::Internet.user
+    User.create!(
+      email: user[:email],
+      password: '123456',
+      name: user[:username],
+      reputation: rand(REPUTATION_RANGE)
+    )
+    puts "Created #{user[:username]}"
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,28 +19,32 @@ DEADLINE_FIRST = Time.now - (DAY_RANGE * seconds_per_day)
 DEADLINE_LAST = Time.now + (DAY_RANGE * seconds_per_day)
 NUMBER_OF_CHOICE_POINTS = 3
 HIGHEST_SCORE = 100
+# Odds that a user votes for a particular choice point.
+VOTE_PROBABILITY = 2.0 / 3.0
 
 def create_users
   USERNAMES.each do |username|
-    email = Faker::Internet.email
-    password = Faker::Internet.password
+    email = "#{username}@mail.com"
+    password = '123456'
     user = User.create!(
       email: email,
       password: password,
       name: username,
       reputation: rand(5..40)
     )
-    puts "Created user #{username}\n\tEmail: #{email}\n\tPassword: #{password}"
+    puts "Created user #{username}\n\tEmail: #{email}\n\tPassword: '#{password}'"
     create_choice_points(user)
   end
 end
 
 def make_users_vote
   User.all.each do |user|
-    choice_points.each do |choice_point|
-      unless choice_point.user == user
-        choice_point.vote(sample(choice_point.options))
-      end
+    ChoicePoint.all.each do |choice_point|
+      next if choice_point.user == user || rand > VOTE_PROBABILITY
+
+      option = choice_point.options.sample
+      vote = Vote.create!(option: option, user: user)
+      option.increase_score(vote)
     end
   end
 end
@@ -69,7 +73,7 @@ def create_options(choice_point, option_descriptions)
       pros: Faker::Lorem.sentence,
       cons: Faker::Lorem.sentence,
       choice_point: choice_point,
-      score: HIGHEST_SCORE * rand
+      # score: HIGHEST_SCORE * rand
     )
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,6 +35,16 @@ def create_users
   end
 end
 
+def make_users_vote
+  User.all.each do |user|
+    choice_points.each do |choice_point|
+      unless choice_point.user == user
+        choice_point.vote(sample(choice_point.options))
+      end
+    end
+  end
+end
+
 def create_choice_points(user)
   NUMBER_OF_CHOICE_POINTS.times do
     title, option_descriptions = CHOICE_POINTS.sample
@@ -68,4 +78,5 @@ puts "Destroying existing users and choice points"
 User.destroy_all
 puts "Creating seeds..."
 create_users
+make_users_vote
 puts "New seeds created"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -73,7 +73,7 @@ def create_options(choice_point, option_descriptions)
       pros: Faker::Lorem.sentence,
       cons: Faker::Lorem.sentence,
       choice_point: choice_point,
-      # score: HIGHEST_SCORE * rand
+      score: HIGHEST_SCORE * rand
     )
   end
 end


### PR DESCRIPTION
The choice point show page now displays Font Awesome icons: a checkmark to indicate the option that the user voted for, and a prize icon to indicate the winning option for past choice points. There's an indication of when voting ended for past choice points, as well as a tally of the total number of votes (for both past and future choice points).

Seeding now creates many more users than before, and each created user randomly votes on created choice points, so that if you log in as a seeded user, you will be able to see that you have already voted on some of the choice points, and you will be able to see that many other people have voted on these choice points. (Unfortunately, this means seeding takes much longer now, but hopefully this will be manageable.)

Finally, I added some documentation to the methods I wrote in the ChoicePoint model, so that it's obvious what each method does.

A past choice point:
![image](https://user-images.githubusercontent.com/80717525/173354158-9c56d5bf-1e78-4c46-b58e-b6f941c6b3db.png)

Another past choice point:
![image](https://user-images.githubusercontent.com/80717525/173354665-d7cfc6b8-f499-4b1a-9139-2629e1934ba7.png)

A future choice point:
![image](https://user-images.githubusercontent.com/80717525/173354744-2f3ff4a5-21b1-421e-897e-addec9a8110c.png)
