### PR TITLE
Tidied up spacing in show page

### DIFF
--- a/app/assets/stylesheets/choicepoint/show.scss
+++ b/app/assets/stylesheets/choicepoint/show.scss
@@ -71,11 +71,12 @@
   padding-bottom: 16px;
   margin-bottom: 48px;
   display: grid;
-  grid-template-columns: 2fr 43fr 8fr 8fr 5fr 34fr;
+  grid-template-columns: 0fr 43fr 2fr 16fr 2fr 34fr;
   grid-template-rows: 1fr;
   grid-auto-rows: auto;
   // gap: 16px;
   align-items: center;
+  grid-row-gap: 8px;
   .show-option-descriptions {
     display: flex;
     flex-direction: column;
@@ -93,6 +94,10 @@
   }
   .show-options-row-pros-and-cons {
     text-transform: uppercase;
+    padding: 6px 16px;
+  }
+  .pros-and-cons-container {
+    gap: 16px;
   }
   .show-options-check-mark {
     font-size: 20px;
@@ -143,10 +148,12 @@
 
 .show-container {
   .show-options > * {
-    padding: 16px;
+    padding: 8px 13px;
+    margin: 8px 0;
     height: 100%;
     display: flex;
     align-items: center;
+    margin: 4px 0;
   }
   .show-options-header-row {
     font-size: $paragraph-size;

--- a/app/views/choice_points/_voting_area_content.html.erb
+++ b/app/views/choice_points/_voting_area_content.html.erb
@@ -16,8 +16,9 @@
 <% options = choice_point.options.order(expired ? 'score DESC' : :id) %>
 <% options.each do |option| %>
   <%= yield(option) %>
-  <div>
-    <p><a class="btn btn-ghost show-options-row-pros-and-cons" data-bs-toggle="modal" href="#prosToggle<%= option.id %>">Pros</a></p>
+  <!-- spacer div for the grid --> <div></div>
+  <div class="pros-and-cons-container">
+    <p><a class="btn btn-info show-options-row-pros-and-cons" data-bs-toggle="modal" href="#prosToggle<%= option.id %>">Pros</a></p>
     <div class="modal fade" id="prosToggle<%= option.id %>" aria-hidden="true" aria-labelledby="prosToggleLabel<%= option.id %>" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
@@ -34,9 +35,7 @@
         </div>
       </div>
     </div>
-  </div>
-  <div>
-    <p><a class="btn btn-ghost show-options-row-pros-and-cons" data-bs-toggle="modal" href="#consToggle<%= option.id %>">Cons</a></p>
+    <p><a class="btn btn-info show-options-row-pros-and-cons" data-bs-toggle="modal" href="#consToggle<%= option.id %>">Cons</a></p>
     <div class="modal fade" id="consToggle<%= option.id %>" aria-hidden="true" aria-labelledby="consToggleLabel<%= option.id %>" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">

--- a/app/views/choice_points/show.html.erb
+++ b/app/views/choice_points/show.html.erb
@@ -1,4 +1,3 @@
-<%# TODO: View should look different after deadline has passed %>
 <div class="show-view">
   <div class="show-container">
     <div class="show-header">
@@ -6,7 +5,6 @@
         <div class="asker"><%= @user_string %></div>
         <div class="question"><%= @title %></div>
       </h1>
-      <p><a class="btn btn-ghost spaced" id="more" href="#">More</a></p>
     </div>
     <h3 class="description"><%= @choice_point.description %></h3>
     <% no_vote = @user_has_voted || @belongs_to_current_user || @expired %>


### PR DESCRIPTION
The "pros" and "cons" buttons on the show page are now spaced a little more evenly. I've made the buttons a bit thicker as well.

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/80717525/173711733-f3217665-c292-44b9-8c99-e99bda057372.png">

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/80717525/173712204-b55fffb9-355e-4900-8d01-f6decfe23f92.png">

