### PR TITLE
Voting no longer reloads show page

### DIFF
--- a/app/assets/stylesheets/choicepoint/show.scss
+++ b/app/assets/stylesheets/choicepoint/show.scss
@@ -71,11 +71,12 @@
   padding-bottom: 16px;
   margin-bottom: 48px;
   display: grid;
-  grid-template-columns: 2fr 43fr 8fr 8fr 5fr 34fr;
+  grid-template-columns: 0fr 43fr 2fr 16fr 2fr 34fr;
   grid-template-rows: 1fr;
   grid-auto-rows: auto;
   // gap: 16px;
   align-items: center;
+  grid-row-gap: 8px;
   .show-option-descriptions {
     display: flex;
     flex-direction: column;
@@ -93,6 +94,10 @@
   }
   .show-options-row-pros-and-cons {
     text-transform: uppercase;
+    padding: 6px 16px;
+  }
+  .pros-and-cons-container {
+    gap: 16px;
   }
   .show-options-check-mark {
     font-size: 20px;
@@ -143,10 +148,12 @@
 
 .show-container {
   .show-options > * {
-    padding: 16px;
+    padding: 8px 13px;
+    margin: 8px 0;
     height: 100%;
     display: flex;
     align-items: center;
+    margin: 4px 0;
   }
   .show-options-header-row {
     font-size: $paragraph-size;

--- a/app/assets/stylesheets/choicepoint/show.scss
+++ b/app/assets/stylesheets/choicepoint/show.scss
@@ -63,13 +63,16 @@
   padding: 24px;
 }
 
+.show-options {
+  margin-bottom: 48px;
+}
+
 .show-container .show-options {
   background-color: $white;
   box-shadow: 0 4px 8px rgba(0, 0, 0, .25);
   border-radius: 16px;
   padding: 24px;
   padding-bottom: 16px;
-  margin-bottom: 48px;
   display: grid;
   grid-template-columns: 0fr 43fr 2fr 16fr 2fr 34fr;
   grid-template-rows: 1fr;
@@ -161,6 +164,10 @@
     text-transform: uppercase;
     padding: 0 16px;
   }
+}
+
+.active-votes-container {
+  margin-bottom: 98.18px;
 }
 
 // Not DRY, will fix later

--- a/app/controllers/choice_points_controller.rb
+++ b/app/controllers/choice_points_controller.rb
@@ -49,13 +49,20 @@ class ChoicePointsController < ApplicationController
     @vote = Vote.new
     @vote.user = current_user
     @vote.option = @option
-    if @vote.save
-      @option.increase_score(@vote)
-      @choice_point = ChoicePoint.find(params[:id])
-      redirect_to choice_point_path(@choice_point)
-    else
-      # I don't think this will work. Is this branch even needed?
-      render :show
+    @vote.save!
+    @option.increase_score(@vote)
+    @choice_point = ChoicePoint.find(params[:id])
+    respond_to do |format|
+      format.html do
+        redirect_to choice_point_path(@choice_point)
+      end
+      format.text do
+        render partial: "choice_points/results",
+               locals: { choice_point: @choice_point,
+                         highest_score: @choice_point.highest_score,
+                         expired: @choice_point.expired },
+               formats: [:html]
+      end
     end
   end
 

--- a/app/javascript/controllers/choice_point_voting_form_controller.js
+++ b/app/javascript/controllers/choice_point_voting_form_controller.js
@@ -1,9 +1,24 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["voteButton"]
+  static targets = ["form", "voteButton"]
 
   enableVoteButton() {
     this.voteButtonTarget.removeAttribute("disabled")
+  }
+
+  update(event) {
+    console.log("I'm here!!!")
+    event.preventDefault()
+    const url = this.formTarget.action
+    fetch(url, {
+      method: "PATCH",
+      headers: { "Accept": "text/plain" },
+      body: new FormData(this.formTarget)
+    })
+      .then(response => response.text())
+      .then((data) => {
+        this.formTarget.outerHTML = data
+      })
   }
 }

--- a/app/views/choice_points/_results.html.erb
+++ b/app/views/choice_points/_results.html.erb
@@ -1,4 +1,4 @@
-<div class="show-options votes-container">
+<div class="show-options votes-container <%= "active-votes-container" unless expired %>">
   <%= render "voting_area_content",
       choice_point: choice_point,
       highest_score: highest_score,

--- a/app/views/choice_points/_voting_area_content.html.erb
+++ b/app/views/choice_points/_voting_area_content.html.erb
@@ -16,8 +16,9 @@
 <% options = choice_point.options.order(expired ? 'score DESC' : :id) %>
 <% options.each do |option| %>
   <%= yield(option) %>
-  <div>
-    <p><a class="btn btn-ghost show-options-row-pros-and-cons" data-bs-toggle="modal" href="#prosToggle<%= option.id %>">Pros</a></p>
+  <!-- spacer div for the grid --> <div></div>
+  <div class="pros-and-cons-container">
+    <p><a class="btn btn-info show-options-row-pros-and-cons" data-bs-toggle="modal" href="#prosToggle<%= option.id %>">Pros</a></p>
     <div class="modal fade" id="prosToggle<%= option.id %>" aria-hidden="true" aria-labelledby="prosToggleLabel<%= option.id %>" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
@@ -34,9 +35,7 @@
         </div>
       </div>
     </div>
-  </div>
-  <div>
-    <p><a class="btn btn-ghost show-options-row-pros-and-cons" data-bs-toggle="modal" href="#consToggle<%= option.id %>">Cons</a></p>
+    <p><a class="btn btn-info show-options-row-pros-and-cons" data-bs-toggle="modal" href="#consToggle<%= option.id %>">Cons</a></p>
     <div class="modal fade" id="consToggle<%= option.id %>" aria-hidden="true" aria-labelledby="consToggleLabel<%= option.id %>" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">

--- a/app/views/choice_points/_voting_form.html.erb
+++ b/app/views/choice_points/_voting_form.html.erb
@@ -1,7 +1,9 @@
 <%= form_with(model: choice_point,
               url: vote_choice_point_path(choice_point),
               html: { class: 'votes-container',
-                      data: { controller: 'choice-point-voting-form' } }) do |form| %>
+                      data: { controller: 'choice-point-voting-form',
+                              choice_point_voting_form_target: 'form',
+                              action: "submit->choice-point-voting-form#update" } }) do |form| %>
 
   <div class="show-options">
 

--- a/app/views/choice_points/show.html.erb
+++ b/app/views/choice_points/show.html.erb
@@ -1,4 +1,3 @@
-<%# TODO: View should look different after deadline has passed %>
 <div class="show-view">
   <div class="show-container">
     <div class="show-header">
@@ -6,7 +5,6 @@
         <div class="asker"><%= @user_string %></div>
         <div class="question"><%= @title %></div>
       </h1>
-      <p><a class="btn btn-ghost spaced" id="more" href="#">More</a></p>
     </div>
     <h3 class="description"><%= @choice_point.description %></h3>
     <% no_vote = @user_has_voted || @belongs_to_current_user || @expired %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,7 +21,7 @@ DEADLINE_LAST = Time.now + (DAY_RANGE * seconds_per_day)
 NUMBER_OF_CHOICE_POINTS = 3
 HIGHEST_SCORE = 100
 # Odds that a user votes for a particular choice point.
-VOTE_PROBABILITY = 2.0 / 3.0
+VOTE_PROBABILITY = 1.0 / 2.0
 REPUTATION_RANGE = 5..40
 
 def create_users


### PR DESCRIPTION
Now when you vote for an option on the show page, instead of reloading the whole page, it simply updates the options container, replacing the voting form with the results. It could still be made a bit smoother—currently, the grid in the options container resizes slightly after voting, to make extra space for the checkmark symbol—but we can worry about that later (if at all).