### PR TITLE
Widen deadline column in last chance container

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -225,7 +225,7 @@ article.card-product footer ul {
   line-height: 1.4;
   opacity: .7;
   margin-bottom: 0;
-  width: 11%;
+  width: 16%;
   text-align: right;
 }
 


### PR DESCRIPTION
This PR increases the width of the deadline column in the "Last chance" container on the homepage, to ensure that deadlines that take up a lot of visual space (e.g., "About 2 months") don't get cut off, and don't unnecessarily wrap onto multiple lines.